### PR TITLE
order loans by due date

### DIFF
--- a/app/Resources/views/member_site/loan/loan_search.html.twig
+++ b/app/Resources/views/member_site/loan/loan_search.html.twig
@@ -69,7 +69,10 @@
 
             $('.data-table').DataTable({
                 pageLength: 50,
-                ordering: true
+                ordering: true,
+                order: [
+                    [3, 'desc']
+                ]
             });
         });
     </script>


### PR DESCRIPTION
Sets a default sort order on 'Due date' for loans/reservation (loan-search page).
Without default, the sort is on 'status' and show all 'cancelled'/'closed' loans first